### PR TITLE
Remove self-dependency in "@dub/ui" and "@dub/utils"

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@dub/ui": "workspace:^",
     "@radix-ui/react-accordion": "^1.0.1",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "1.0.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@dub/utils": "workspace:^",
     "@sindresorhus/slugify": "^2.2.1",
     "chrono-node": "^2.7.5",
     "clsx": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,9 +389,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@dub/ui':
-        specifier: workspace:^
-        version: 'link:'
       '@radix-ui/react-accordion':
         specifier: ^1.0.1
         version: 1.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -501,9 +498,6 @@ importers:
 
   packages/utils:
     dependencies:
-      '@dub/utils':
-        specifier: workspace:^
-        version: 'link:'
       '@sindresorhus/slugify':
         specifier: ^2.2.1
         version: 2.2.1


### PR DESCRIPTION
## Summarise the feature

Issue ticket #18 

Description:
Remove self-dependency in "@dub/ui" and "@dub/utils" so we can run `pnpm dev` at root directory with turborepo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
