### PR TITLE
Unit tests not pass #50

### DIFF
--- a/apps/web/lib/api/links/process-link.ts
+++ b/apps/web/lib/api/links/process-link.ts
@@ -226,19 +226,17 @@ export async function processLink<T extends Record<string, any>>({
           code: "unprocessable_entity",
         };
       }
-    } catch (e){
+    } catch (e) {
       if (e?.code === "P2023") {
         return {
           link: payload,
-          error:
-            "Invalid tagIds detected: invalid",
+          error: "Invalid tagIds detected: invalid",
           code: "unprocessable_entity",
         };
       }
       return {
         link: payload,
-        error:
-          e?.meta?.message,
+        error: e?.meta?.message,
         code: e.code,
       };
     }


### PR DESCRIPTION
## Summarise the feature
ISSUE:
"create link with invalid tag id" did not pass test because prisma triggers 500 error when the UUID validation fails with error message : "Error creating UUID, invalid character: expected an optional prefix of urn:uuid: followed by [0-9a-fA-F]"

SOLUTION:
added try catch block around process link function and if it throws P2023 error code, return 422 with DubAPiError unprocessable_entity code.

RESULT:
![image](https://github.com/govtechmy/go-gov-my/assets/169971359/f1c322a1-ab3f-40ce-9d00-4bfbe2fceeeb)

Issue ticket # (issue)

Description:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Backend / Frontend / Endpoint / Functions

pnpm test
process-link

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
