### PR TITLE
Fix link middleware

### DIFF
--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -1,6 +1,6 @@
 import { detectBot, getFinalUrl, parse } from "@/lib/middleware/utils";
 import {
-  API_DOMAIN,
+  APP_DOMAIN,
   DUB_DEMO_LINKS,
   DUB_HEADERS,
   LEGAL_WORKSPACE_ID,
@@ -57,7 +57,7 @@ export default async function LinkMiddleware(
     domain: string,
     key: string,
   ): Promise<LinkMiddlewareLinkDataResponse> {
-    const url = new URL("/api/middleware/link/link-data", API_DOMAIN);
+    const url = new URL("/api/middleware/link/link-data", APP_DOMAIN);
     url.searchParams.set("domain", domain);
     url.searchParams.set("key", key);
     const response = await fetch(url);
@@ -68,7 +68,7 @@ export default async function LinkMiddleware(
   if (!linkData) {
     // short link not found, redirect to root
     // TODO: log 404s (https://github.com/dubinc/dub/issues/559)
-    return NextResponse.redirect(new URL("/", req.url), {
+    return NextResponse.redirect(new URL("/", APP_DOMAIN), {
       ...DUB_HEADERS,
       status: 302,
     });

--- a/packages/utils/src/constants/middleware.ts
+++ b/packages/utils/src/constants/middleware.ts
@@ -17,6 +17,6 @@ export const DEFAULT_REDIRECTS = {
 
 export const DUB_HEADERS = {
   headers: {
-    "x-powered-by": `${APP_NAME} – Malaysia's open-source link management infrastructure`,
+    "x-powered-by": `${APP_NAME} - Malaysia's open-source link management infrastructure`,
   },
 };


### PR DESCRIPTION
## Summarise the feature

Fix bugs:
- Fetch request failing due to invalid url
- Failure to send response due to error encoding the `–` character in response headers

Testing:
- We can test the link middleware locally by visiting http://dub.localhost:8888/{linkKey}
- Example: I have a short link "go.gov.my/gGPsLoX" in my workspace, I can test it during local dev by visiting "http://dub.localhost:8888/gGPsLoX"

We will migrate to golang anyways for redirects but still good to test out the current logic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
