### PR TITLE
feat: add docker container for uptime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
       - 8083:8083
     networks:
       - my-network
-  
+
   init-debezium-connector:
     image: curlimages/curl:8.8.0
     depends_on:
@@ -191,13 +191,14 @@ services:
       - debezium
     networks:
       - my-network
-  uptime-kuma:
+
+  status-page:
     image: louislam/uptime-kuma:1
     restart: always
     volumes:
       - uptime-kuma:/app/data
     ports:
-      - 3002:3001
+      - 3002:3002
     networks:
       - my-network
 
@@ -206,4 +207,4 @@ networks:
 
 volumes:
   ps-postgres:
-  uptime-kuma:
+  status-page:


### PR DESCRIPTION
## Summarise the feature

added docker image uptime-kuma using port 3001

there is option for non docker setup but as per your comment yesterday , they will want docker

uptime requires creating an account initially, then enter settings -> security -> advance -> disable auth at bottom to enable public viewing

There is no configuration as a code option, i believe they store their state in a .db file, so if we edit locally we have to edit .db file and then upload to the instance that are in deployment everytime.

Would like to point out that its possible to export settings as a json file (monitors included), and then reimport it to apply new changes.

Issue ticket # (issue)

Description:

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [/] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Backend / Frontend / Endpoint / Functions

- xxx
- xxx
- xxx

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
