### PR TITLE
Fix `localhost:8888/en` shows no workspace page

### DIFF
--- a/apps/web/lib/middleware/utils/parse.ts
+++ b/apps/web/lib/middleware/utils/parse.ts
@@ -12,9 +12,13 @@ export const parse = (req: NextRequest) => {
 
   // path is the path of the URL (e.g. dub.co/stats/github -> /stats/github)
   let path = req.nextUrl.pathname;
+  const firstPathSegment = path.split("/").at(1);
 
   // if path has no locale, add in default locale
-  if (path === "/" || !LOCALES.some((locale) => path.startsWith(`/${locale}/`)))
+  if (
+    !firstPathSegment ||
+    !LOCALES.some((locale) => firstPathSegment === locale)
+  )
     path = `/${DEFAULT_LOCALE}${path}`;
 
   let locale = decodeURIComponent(path.split("/")[1]);


### PR DESCRIPTION
## Summarise the feature

Description:
- Update parse util function in middleware
- pathWithoutLocale was parsed incorrectly for the "/" root page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
