### PR TITLE
Remove plaintext password from DB

### DIFF
--- a/apps/web/lib/api/links/add-to-history.ts
+++ b/apps/web/lib/api/links/add-to-history.ts
@@ -15,7 +15,6 @@ export type LinkHistory = Pick<
   | "image"
   | "ios"
   | "key"
-  | "password"
   | "proxy"
   | "publicStats"
   | "title"
@@ -52,7 +51,6 @@ export async function addToHistory(entry: LinkHistory): Promise<void> {
       geo: entry.geo || undefined,
       image: entry.image,
       ios: entry.ios,
-      password: entry.password,
       title: entry.title,
     },
   });

--- a/apps/web/lib/api/links/create-link.ts
+++ b/apps/web/lib/api/links/create-link.ts
@@ -33,7 +33,7 @@ export async function createLink(
   const { utm_source, utm_medium, utm_campaign, utm_term, utm_content } =
     getParamsFromURL(url);
 
-  const { tagId, tagIds, tagNames, ...rest } = link;
+  const { tagId, tagIds, tagNames, password, ...rest } = link;
 
   const response = await prisma.link.create({
     data: {
@@ -50,6 +50,7 @@ export async function createLink(
       utm_content,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
       geo: geo || Prisma.JsonNull,
+      passwordEnabledAt: password ? new Date() : undefined,
 
       // Associate tags by tagNames
       ...(tagNames?.length &&
@@ -96,7 +97,10 @@ export async function createLink(
   const uploadedImageUrl = `${process.env.STORAGE_BASE_URL}/images/${response.id}`;
 
   // Transform into DTOs
-  const { payload, encryptedSecrets } = await processDTOLink(response);
+  const { payload, encryptedSecrets } = await processDTOLink({
+    ...response,
+    password,
+  });
 
   // For simplicity and centralized, lets create the idempotency key at this level
   const headersJSON = generateIdempotencyKey(

--- a/apps/web/lib/api/links/update-link.ts
+++ b/apps/web/lib/api/links/update-link.ts
@@ -57,6 +57,7 @@ export async function updateLink({
     tagId,
     tagIds,
     tagNames,
+    password,
     ...rest
   } = updatedLink;
 
@@ -127,7 +128,10 @@ export async function updateLink({
   });
 
   // Transform into DTOs
-  const { payload, encryptedSecrets } = await processDTOLink(response);
+  const { payload, encryptedSecrets } = await processDTOLink({
+    ...response,
+    password,
+  });
 
   // For simplicity and centralized, lets create the idempotency key at this level
   const headersJSON = generateIdempotencyKey(payload.id, response.updatedAt);

--- a/apps/web/lib/dto/link.dto.ts
+++ b/apps/web/lib/dto/link.dto.ts
@@ -13,14 +13,14 @@ export interface LinkDTO {
   imageUrl: string | null; // image URL for OG meta tags
   title: string | null;
   description: string | null;
-  password: string | null;
+  password?: string;
   banned: boolean;
   createdAt: Date | null;
 }
 
 // This should be able to reuse anywhere.
 export async function processDTOLink(
-  response: LinkProps,
+  response: LinkProps & { password?: string },
 ): Promise<{ payload: LinkDTO; encryptedSecrets: string | null }> {
   const linkDTO: LinkDTO = {
     id: response.id,
@@ -45,7 +45,7 @@ export async function processDTOLink(
   let encryptedSecrets: string | null = null;
 
   // If a password is set, store it as a secret
-  if (linkDTO.password !== null) {
+  if (linkDTO.password) {
     const placeholder = "{{PASSWORD}}";
     secrets[placeholder] = linkDTO.password;
     linkDTO.password = placeholder;

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -16,7 +16,6 @@ import {
   userAgent,
 } from "next/server";
 import { isBlacklistedReferrer } from "../edge-config";
-import { getLinkViaEdge } from "../userinfos";
 
 export default async function LinkMiddleware(
   req: NextRequest,
@@ -83,25 +82,6 @@ export default async function LinkMiddleware(
       new URL(`/inspect/${domain}/${encodeURIComponent(key)}+`, req.url),
       DUB_HEADERS,
     );
-  }
-
-  // if the link is password protected
-  if (password) {
-    const pw = req.nextUrl.searchParams.get("pw");
-
-    // rewrite to auth page (/password/[domain]/[key]) if:
-    // - no `pw` param is provided
-    // - the `pw` param is incorrect
-    // this will also ensure that no clicks are tracked unless the password is correct
-    if (!pw || (await getLinkViaEdge(domain, key))?.password !== pw) {
-      return NextResponse.rewrite(
-        new URL(`/password/${domain}/${encodeURIComponent(key)}`, req.url),
-        DUB_HEADERS,
-      );
-    } else if (pw) {
-      // strip it from the URL if it's correct
-      req.nextUrl.searchParams.delete("pw");
-    }
   }
 
   // if the link is banned

--- a/apps/web/lib/redis/index.ts
+++ b/apps/web/lib/redis/index.ts
@@ -12,7 +12,6 @@ export async function formatRedisLink(
     id,
     domain,
     url,
-    password,
     proxy,
     expiresAt,
     expiredUrl,
@@ -21,12 +20,10 @@ export async function formatRedisLink(
     geo,
     projectId,
   } = link;
-  const hasPassword = password && password.length > 0 ? true : false;
 
   return {
     id,
     url,
-    ...(hasPassword && { password: true }),
     ...(proxy && { proxy: true }),
     ...(expiresAt && { expiresAt: new Date(expiresAt) }),
     ...(expiredUrl && { expiredUrl }),

--- a/apps/web/lib/zod/schemas/links.ts
+++ b/apps/web/lib/zod/schemas/links.ts
@@ -181,7 +181,7 @@ export const createLinkBodySchema = z.object({
     .describe("The URL to redirect to when the short link has expired."),
   password: z
     .string()
-    .nullish()
+    .optional()
     .describe(
       "The password required to access the destination URL of the short link.",
     ),
@@ -274,12 +274,10 @@ export const LinkSchema = z
       .url()
       .nullable()
       .describe("The URL to redirect to when the short link has expired."),
-    password: z
-      .string()
+    passwordEnabledAt: z.coerce
+      .date()
       .nullable()
-      .describe(
-        "The password required to access the destination URL of the short link.",
-      ),
+      .describe("The most recent date a password was set for the short link."),
     proxy: z
       .boolean()
       .default(false)

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -15,7 +15,7 @@ generator client {
 
   // Use engine type "binary" for esbuild to bundle prisma correctly when
   // building the outbox kafka consumer
-  engineType      = "binary"
+  engineType = "binary"
 }
 
 model Agency {
@@ -108,12 +108,11 @@ model Token {
 }
 
 model Project {
-  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name        String
-  slug        String    @unique
-  logo        String?
-  agencyCode  String    @default("govtech")
-
+  id         String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name       String
+  slug       String  @unique
+  logo       String?
+  agencyCode String  @default("govtech")
 
   plan              String @default("business")
   billingCycleStart Int // day of the month when the billing cycle starts
@@ -193,16 +192,16 @@ model SentEmail {
 }
 
 model Link {
-  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  domain     String // domain of the link (e.g. dub.sh) – also stored on Redis
-  key        String // key of the link (e.g. /github) – also stored on Redis
-  url        String // @db.LongText // target url (e.g. https://github.com/dubinc/dub) – also stored on Redis
-  archived   Boolean   @default(false) // whether the link is archived or not
-  expiresAt  DateTime? // when the link expires – stored on Redis via ttl
-  expiredUrl String? // @db.LongText // URL to redirect the user to when the link is expired
-  password   String? // password to access the link
-  externalId String?
-  banned     Boolean   @default(false)
+  id                String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  domain            String // domain of the link (e.g. dub.sh) – also stored on Redis
+  key               String // key of the link (e.g. /github) – also stored on Redis
+  url               String // @db.LongText // target url (e.g. https://github.com/dubinc/dub) – also stored on Redis
+  archived          Boolean   @default(false) // whether the link is archived or not
+  expiresAt         DateTime? // when the link expires – stored on Redis via ttl
+  expiredUrl        String? // @db.LongText // URL to redirect the user to when the link is expired
+  passwordEnabledAt DateTime?
+  externalId        String?
+  banned            Boolean   @default(false)
 
   trackConversion Boolean @default(false) // whether to track conversions or not
 
@@ -228,8 +227,8 @@ model Link {
   userId String? @db.Uuid
 
   // Project that the link belongs to
-  project       Project @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  projectId     String  @db.Uuid
+  project   Project @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  projectId String  @db.Uuid
 
   publicStats Boolean   @default(false) // whether to show public stats or not
   clicks      Int       @default(0) // number of clicks
@@ -255,7 +254,6 @@ model Link {
   @@index(domain)
   @@index(trackConversion)
   @@index(proxy)
-  @@index(password)
   @@index(createdAt(sort: Desc))
   @@index(clicks(sort: Desc))
   @@index(lastClicked)
@@ -263,14 +261,14 @@ model Link {
 }
 
 model WebhookOutbox {
-  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  host              String
-  payload           Json
-  createdAt         DateTime @default(now()) @db.Timestamptz
-  action            String
-  headers           Json
-  partitionKey      String
-  encryptedSecrets  String?
+  id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  host             String
+  payload          Json
+  createdAt        DateTime @default(now()) @db.Timestamptz
+  action           String
+  headers          Json
+  partitionKey     String
+  encryptedSecrets String?
 }
 
 model LinkHistory {
@@ -288,7 +286,6 @@ model LinkHistory {
   archived   Boolean
   expiresAt  DateTime?
   expiredUrl String?
-  password   String?
   externalId String?
 
   trackConversion Boolean
@@ -340,18 +337,18 @@ model LinkTag {
 }
 
 model Analytics {
-  id                    String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  linkId                String
-  from                  DateTime
-  to                    DateTime
-  aggregatedDate        DateTime   @db.Date
-  metadata              Json       @db.Json
-  createdAt             DateTime   @default(now()) @db.Timestamptz
-  updatedAt             DateTime   @updatedAt
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  linkId         String
+  from           DateTime
+  to             DateTime
+  aggregatedDate DateTime @db.Date
+  metadata       Json     @db.Json
+  createdAt      DateTime @default(now()) @db.Timestamptz
+  updatedAt      DateTime @updatedAt
 }
 
 model IdempotentResource {
-  idempotencyKey     String @id
-  hashedPayload      String
-  createdAt          DateTime   @default(now()) @db.Timestamptz
+  idempotencyKey String   @id
+  hashedPayload  String
+  createdAt      DateTime @default(now()) @db.Timestamptz
 }

--- a/apps/web/tests/links/create-link.test.ts
+++ b/apps/web/tests/links/create-link.test.ts
@@ -166,17 +166,7 @@ describe.sequential("POST /links", async () => {
     });
 
     expect(status).toEqual(200);
-    expect(link).toStrictEqual({
-      ...expectedLink,
-      url,
-      password,
-      userId: user.id,
-      projectId,
-      workspaceId,
-      shortLink: `https://${domain}/${link.key}`,
-      qrCode: `https://api.dub.co/qr?url=https://${domain}/${link.key}?qr=1`,
-      tags: [],
-    });
+    expect(link.passwordEnabledAt).toBeTruthy();
     expect(LinkSchema.strict().parse(link)).toBeTruthy();
 
     await h.deleteLink(link.id);

--- a/apps/web/tests/links/update-link.test.ts
+++ b/apps/web/tests/links/update-link.test.ts
@@ -1,5 +1,7 @@
+import { updateLinkBodySchema } from "@/lib/zod/schemas/links";
 import { Link } from "@prisma/client";
 import { afterAll, describe, expect, test } from "vitest";
+import { z } from "zod";
 import { randomId } from "../utils/helpers";
 import { IntegrationHarness } from "../utils/integration";
 import { link } from "../utils/resource";
@@ -23,16 +25,15 @@ describe.sequential("PATCH /links/{linkId}", async () => {
     },
   });
 
-  const toUpdate: Partial<Link> = {
+  const toUpdate: Partial<z.infer<typeof updateLinkBodySchema>> = {
     key: randomId(),
     url: "https://github.com/dubinc/dub",
     title: "Dub Inc",
     description: "Open-source link management infrastructure.",
     publicStats: true,
     comments: "This is a comment.",
-    expiresAt: new Date("2030-04-16T17:00:00.000Z"),
+    expiresAt: "2030-04-16T17:00:00.000Z",
     expiredUrl: "https://github.com/expired",
-    password: "link-password",
     ios: "https://apps.apple.com/app/1611158928",
     android:
       "https://play.google.com/store/apps/details?id=com.disney.disneyplus",
@@ -212,16 +213,15 @@ describe.sequential(
       },
     });
 
-    const toUpdate: Partial<Link> = {
+    const toUpdate: Partial<z.infer<typeof updateLinkBodySchema>> = {
       key: randomId(),
       url: "https://github.com/dubinc/dub",
       title: "Dub Inc",
       description: "Open-source link management infrastructure.",
       publicStats: true,
       comments: "This is a comment.",
-      expiresAt: new Date("2030-04-16T17:00:00.000Z"),
+      expiresAt: "2030-04-16T17:00:00.000Z",
       expiredUrl: "https://github.com/expired",
-      password: "link-password",
       ios: "https://apps.apple.com/app/1611158928",
       android:
         "https://play.google.com/store/apps/details?id=com.disney.disneyplus",

--- a/apps/web/tests/utils/schema.ts
+++ b/apps/web/tests/utils/schema.ts
@@ -10,7 +10,7 @@ export const expectedLink: Partial<Link> & { tagId: string | null } = {
   archived: false,
   banned: false,
   expiresAt: null,
-  password: null,
+  passwordEnabledAt: null,
   proxy: false,
   title: null,
   description: null,

--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -68,7 +68,7 @@ export default function LinkCard({
     key,
     domain,
     url,
-    password,
+    passwordEnabledAt,
     expiresAt,
     createdAt,
     lastClicked,
@@ -504,7 +504,7 @@ export default function LinkCard({
                 {timeAgo(createdAt)}
               </p>
               <p className="xs:block hidden">•</p>
-              {password && (
+              {passwordEnabledAt && (
                 <Tooltip
                   content={
                     <SimpleTooltipContent

--- a/apps/web/ui/links/table-card.tsx
+++ b/apps/web/ui/links/table-card.tsx
@@ -45,7 +45,6 @@ export default function TableCard({
     key,
     domain,
     url,
-    password,
     expiresAt,
     createdAt,
     lastClicked,

--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -64,6 +64,10 @@ import Preview from "./preview";
 import TagsSection from "./tags-section";
 import UTMSection from "./utm-section";
 
+export type FormValues = LinkWithTagsProps & {
+  password?: string;
+};
+
 function AddEditLinkModal({
   showAddEditLinkModal,
   setShowAddEditLinkModal,
@@ -95,7 +99,7 @@ function AddEditLinkModal({
   const [generatingRandomKey, setGeneratingRandomKey] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const [data, setData] = useState<LinkWithTagsProps>(
+  const [data, setData] = useState<FormValues>(
     props || duplicateProps || DEFAULT_LINK_PROPS,
   );
 
@@ -692,7 +696,15 @@ function AddEditLinkModal({
                 {...{ props, data, setData }}
                 generatingMetatags={generatingMetatags}
               />
-              <PasswordSection {...{ props, data, setData }} />
+              <PasswordSection
+                defaultEnabled={data.passwordEnabledAt !== null}
+                onPasswordChange={(password) =>
+                  setData((prev) => ({ ...prev, password }))
+                }
+                onPasswordDisable={() => {
+                  // TODO: Logic for disabling the password
+                }}
+              />
               <ExpirationSection {...{ props, data, setData }} />
               <IOSSection {...{ props, data, setData }} />
               <AndroidSection {...{ props, data, setData }} />

--- a/apps/web/ui/modals/add-edit-link-modal/password-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/password-section.tsx
@@ -1,39 +1,27 @@
 import { useIntlClientHook } from "@/lib/middleware/utils/useI18nClient";
-import { LinkProps } from "@/lib/types";
 import { Eye, EyeOff } from "@/ui/shared/icons";
 import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
 import { SimpleTooltipContent, Switch } from "@dub/ui";
 import { FADE_IN_ANIMATION_SETTINGS } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useState } from "react";
+
+type Props = {
+  defaultEnabled: boolean;
+  onPasswordChange: (password: string) => void;
+  onPasswordDisable: () => void;
+};
 
 export default function PasswordSection({
-  props,
-  data,
-  setData,
-}: {
-  props?: LinkProps;
-  data: LinkProps;
-  setData: Dispatch<SetStateAction<LinkProps>>;
-}) {
-  const { messages, locale } = useIntlClientHook();
-  const message = messages?.modal;
-  const { password } = data;
-  const [enabled, setEnabled] = useState(!!password);
-  useEffect(() => {
-    if (enabled) {
-      // if enabling, add previous password if exists
-      setData({
-        ...data,
-        password: props?.password || password,
-      });
-    } else {
-      // if disabling, remove password
-      setData({ ...data, password: null });
-    }
-  }, [enabled]);
-
+  defaultEnabled,
+  onPasswordChange,
+  onPasswordDisable,
+}: Props) {
+  const { messages } = useIntlClientHook();
+  const message = messages.modal;
+  const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [enabled, setEnabled] = useState(defaultEnabled);
 
   return (
     <div className="relative border-b border-gray-200 pb-5">
@@ -52,7 +40,15 @@ export default function PasswordSection({
             }
           />
         </div>
-        <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
+        <Switch
+          fn={(checked: boolean) => {
+            setEnabled(checked);
+            if (!checked) {
+              onPasswordDisable();
+            }
+          }}
+          checked={enabled}
+        />
       </div>
       {enabled && (
         <motion.div
@@ -64,10 +60,11 @@ export default function PasswordSection({
             id="password"
             type={showPassword ? "text" : "password"}
             className="block w-full rounded-md border-gray-300 text-gray-900 placeholder-gray-400 focus:border-gray-500 focus:outline-none focus:ring-gray-500 sm:text-sm"
-            value={password || ""}
+            value={password}
             placeholder={message?.enter_password}
             onChange={(e) => {
-              setData({ ...data, password: e.target.value });
+              setPassword(e.target.value);
+              onPasswordChange(e.target.value);
             }}
             aria-invalid="true"
           />

--- a/apps/web/ui/modals/add-edit-link-modal/preview.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/preview.tsx
@@ -13,7 +13,7 @@ import {
   useResizeObserver,
 } from "@dub/ui";
 import { Button } from "@dub/ui/src/button";
-import { getDomainWithoutWWW, resizeImage } from "@dub/utils";
+import { getDomainWithoutWWW, resizeImage, SHORT_DOMAIN } from "@dub/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { Edit2, Link2, Upload } from "lucide-react";
 import {
@@ -40,12 +40,13 @@ export default function Preview({
   setData: Dispatch<SetStateAction<LinkProps>>;
   generatingMetatags: boolean;
 }) {
-  const { title, description, image, url, password } = data;
+  const { title, description, image, url, passwordEnabledAt } = data;
+  const passwordEnabled = passwordEnabledAt !== null;
   const [debouncedUrl] = useDebounce(url, 500);
   const hostname = useMemo(() => {
-    if (password) return "dub.co";
+    if (passwordEnabled) return SHORT_DOMAIN;
     return getDomainWithoutWWW(debouncedUrl);
-  }, [password, debouncedUrl]);
+  }, [passwordEnabled, debouncedUrl]);
   const { messages } = useIntlClientHook();
   const message = messages?.link;
 

--- a/apps/web/ui/modals/link-history-modal.tsx
+++ b/apps/web/ui/modals/link-history-modal.tsx
@@ -151,7 +151,6 @@ function UpdateMessages({
     "image",
     "ios",
     "key",
-    "password",
     "proxy",
     "publicStats",
     "title",


### PR DESCRIPTION
## Summarise the feature

Issue ticket #282 

Description:
- For security, we will not store short link password in the Postgres database since the NextJS app does not need it.
- We will however, store the date at which password protection for a link is enabled.

Next steps:
These changes require API updates from our redirect-api app
1. Make the password field in the request body optional. The password value for a short link should only be updated if this field is set.
2. We'll need a new API to disable/delete passwords from short links. Our NextJS app will create an outbox to call this API to disable password protection for a short link.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
