### PR TITLE
Fix/302 missing storage keys

### DIFF
--- a/apps/web/lib/api/links/process-link.ts
+++ b/apps/web/lib/api/links/process-link.ts
@@ -194,14 +194,15 @@ export async function processLink<T extends Record<string, any>>({
     }
   }
 
+  /// Farhan 20240912: We don't need this anymore since we are connecting to GovTech AWS SSO
   // custom social media image checks (see if R2 is configured)
-  if (proxy && !process.env.STORAGE_SECRET_ACCESS_KEY) {
-    return {
-      link: payload,
-      error: "Missing storage access key.",
-      code: "bad_request",
-    };
-  }
+  // if (proxy && !process.env.STORAGE_SECRET_ACCESS_KEY) {
+  //   return {
+  //     link: payload,
+  //     error: "Missing storage access key.",
+  //     code: "bad_request",
+  //   };
+  // }
 
   // expire date checks
   if (expiresAt) {


### PR DESCRIPTION
## Summarise the feature

Issue ticket #302 

Description:
Since we are using SSO now to upload image to S3, we no longer need to check for Secret is available or not via our .env.

As Daniel said:
```
Nope not anymore, there's two ways I suggest to authenticate the AWS SDKs now for development:
1. Use AWS resources from govtech's acocunt and run aws sso login --profile govtech-dev
2. Or set AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET like we did initially
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Backend / Frontend / Endpoint / Functions

`./apps/web/lib/api/links/process-link.ts`

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
