### PR TITLE
fix link creation domain bug

### DIFF
--- a/packages/utils/src/constants/index.ts
+++ b/packages/utils/src/constants/index.ts
@@ -23,7 +23,7 @@ if (!process.env.NEXT_PUBLIC_APP_DOMAIN) {
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME;
 
 // This should be your app short link domain i.e. app.go.gov.my
-export const SHORT_DOMAIN = process.env.NEXT_PUBLIC_APP_SHORT_DOMAIN;
+export const SHORT_DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN;
 
 // This should be your main short link domain i.e. go.gov.my
 export const HOME_DOMAIN = `https://${process.env.NEXT_PUBLIC_APP_DOMAIN}`;


### PR DESCRIPTION
## Summarise the feature

Issue ticket # (issue)

in 3dcb5f5c2a3d45f60c45d4fdd76a4c979d6506a8 (8 days ago)

you changed

"NEXT_PUBLIC_APP_SHORT_DOMAIN=pautan.org" 

into 

"NEXT_PUBLIC_APP_SHORT_DOMAIN=app.pautan.org"

.github/workflows/web.yaml

for reasons I am not sure

but in /packages/utils/src/constants/index.ts

export const SHORT_DOMAIN = process.env.NEXT_PUBLIC_APP_SHORT_DOMAIN;

we use process.env.NEXT_PUBLIC_APP_SHORT_DOMAIN as SHORT_DOMAIN to create link

since SHORT_DOMAIN is now app.pautan.org, link created also default with app.pautan.org in front

**My change**

we have NEXT_PUBLIC_APP_DOMAIN which is pautan.org, lets just use that 


Description:

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Backend / Frontend / Endpoint / Functions

- xxx
- xxx
- xxx

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
