### PR TITLE
ops: add svc account for AWS

### DIFF
--- a/.kube/web/base/deployment.yaml
+++ b/.kube/web/base/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: web
     spec:
+      serviceAccountName: gogov-backend-aws-sa
       containers:
         - name: web
           image: web-placeholder

--- a/.kube/web/base/kustomization.yaml
+++ b/.kube/web/base/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - deployment.yaml
   - service.yaml
+  - service-account.yaml

--- a/.kube/web/base/service-account.yaml
+++ b/.kube/web/base/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gogov-backend-aws-sa
+  namespace: gogov


### PR DESCRIPTION
Add service accounts for our deployments so we can attach IAM roles to them to access AWS services

gogov-backend-aws-sa